### PR TITLE
CheckDataRegression(): Add family argument to if clause to prevent transformation of continuous outcomes to ranks.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sharp
 Type: Package
 Title: Stability-enHanced Approaches using Resampling Procedures
-Version: 1.4.4
+Version: 1.4.5
 Date: 2023-10-21
 Author: Barbara Bodinier [aut, cre]
 Maintainer: Barbara Bodinier <barbara.bodinier@gmail.com>

--- a/R/check.R
+++ b/R/check.R
@@ -226,7 +226,7 @@ CheckDataRegression <- function(xdata, ydata = NULL,
       }
     }
     # Turning vector into factor
-    if (is.vector(ydata)) {
+    if ((family %in% c("binomial", "multinomial")) & is.vector(ydata)) {
       ydata <- as.factor(ydata)
     }
     # Defining reference category and final data type


### PR DESCRIPTION
As previously discussed, 

In CheckDataRegression(), all one-column ydata (even continuous ydata) are currently transformed into factors (and later changed back to numeric, subtracting 1 for the reference category). This effectively changes continuous outcomes into ranks of the continuous outcome (minus 1). 

Adding the family argument to the if-clause prevents continuous outcomes from being transformed into ranks.